### PR TITLE
Fix corrupted imports after ai failures

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useGoalSettingData } from '../hooks/useGoalSettingData';
+import { useDashboardData } from '../hooks/useDashboardData';
+import Navigation from './Navigation';
+
+type ViewType = 'dashboard' | 'wheel-of-life' | 'values' | 'vision' | 'goals' | 'calendar' | 'templates';
 
 const Dashboard = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);


### PR DESCRIPTION
Add missing imports and type definition to Dashboard.tsx to resolve cascading module resolution errors.

Previous attempts to fix UI issues led to a corrupted `Dashboard.tsx` file, where critical imports for `useDashboardData`, `Navigation`, and the `ViewType` definition were lost or never added, causing `ReferenceError: useNavigate is not defined` and other related module resolution failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cea4026-4c45-49b0-97d5-15a794adf4fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cea4026-4c45-49b0-97d5-15a794adf4fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

